### PR TITLE
Handle missing JobQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ## Как запустить
 
-1. Установите зависимости:
+1. Установите зависимости (включая поддержку `JobQueue`):
    ```bash
-   pip install python-telegram-bot==20.0
+   pip install "python-telegram-bot[job_queue]==20.0"
    ```
 2. Создайте файл `.env` или задайте переменные окружения:
    - `BOT_TOKEN` — токен вашего бота.

--- a/main.py
+++ b/main.py
@@ -98,7 +98,16 @@ async def main():
     application.add_handler(conv)
 
     # Job to send tasks daily at 9:00 on weekdays
-    application.job_queue.run_daily(send_daily_tasks, time(hour=9, minute=0), days=(0, 1, 2, 3, 4))
+    if application.job_queue:
+        application.job_queue.run_daily(
+            send_daily_tasks,
+            time(hour=9, minute=0),
+            days=(0, 1, 2, 3, 4),
+        )
+    else:
+        print(
+            "Warning: JobQueue is not available. Install python-telegram-bot[job_queue] to enable scheduled tasks."
+        )
 
     await application.initialize()
     await application.start()


### PR DESCRIPTION
## Summary
- add check for `JobQueue` and warning when missing
- document how to install PTB with JobQueue support

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_68539c403c6c832785989684404dbe26