### PR TITLE
Добавить функцию для тега задачи

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -14,6 +14,7 @@ def build_keyboard(tasks, include_add_button=False):
                 )
             ])
             keyboard.append([
+                InlineKeyboardButton('🏷️', callback_data=f"tag_{task['id']}"),
                 InlineKeyboardButton('✏️', callback_data=f"edit_{task['id']}"),
                 InlineKeyboardButton('🗑️', callback_data=f"delete_{task['id']}"),
             ])


### PR DESCRIPTION
## Summary
- show new button to add tags when listing tasks
- allow adding tags separately from edit dialog
- remove tag step from the edit task workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6853f7c84fe88327bf51ef394a044536