### PR TITLE
Improve navigation and reset in Telegram bot

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,7 +1,12 @@
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 
-def build_keyboard(tasks, include_add_button=False):
+def build_cancel_keyboard(text: str = 'Отмена') -> InlineKeyboardMarkup:
+    print('DEBUG: build_cancel_keyboard')
+    return InlineKeyboardMarkup([[InlineKeyboardButton(text, callback_data='cancel')]])
+
+
+def build_keyboard(tasks, include_add_button: bool = False, include_back_button: bool = False) -> InlineKeyboardMarkup | None:
     print('DEBUG: build_keyboard')
     keyboard = []
     for task in tasks:
@@ -20,12 +25,14 @@ def build_keyboard(tasks, include_add_button=False):
             ])
     if include_add_button:
         keyboard.append([InlineKeyboardButton('Добавить задачу', callback_data='add_task')])
+    if include_back_button:
+        keyboard.append([InlineKeyboardButton('Назад', callback_data='cancel')])
     if keyboard:
         return InlineKeyboardMarkup(keyboard)
     return InlineKeyboardMarkup([[InlineKeyboardButton('Добавить задачу', callback_data='add_task')]]) if include_add_button else None
 
 
-def build_completed_keyboard(tasks):
+def build_completed_keyboard(tasks, include_back_button: bool = False) -> InlineKeyboardMarkup | None:
     print('DEBUG: build_completed_keyboard')
     keyboard = []
     for task in tasks:
@@ -37,6 +44,8 @@ def build_completed_keyboard(tasks):
                     callback_data=f"restore_{task['id']}"
                 )
             ])
+    if include_back_button:
+        keyboard.append([InlineKeyboardButton('Назад', callback_data='cancel')])
     if keyboard:
         return InlineKeyboardMarkup(keyboard)
     return None

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -25,7 +25,15 @@ def schedule_reminder_job(application: Application):
     )
 
 
-async def reply_or_edit(update: Update, text: str, reply_markup=None):
+async def send_and_store(context, chat_id: int, text: str, reply_markup=None):
+    print('DEBUG: send_and_store')
+    sent = await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=reply_markup)
+    if hasattr(context, 'chat_data'):
+        context.chat_data.setdefault('bot_messages', set()).add(sent.message_id)
+    return sent
+
+
+async def reply_or_edit(update: Update, context, text: str, reply_markup=None):
     """Send or edit message depending on update type."""
     message = update.message or (update.callback_query and update.callback_query.message)
     if update.callback_query:
@@ -34,6 +42,8 @@ async def reply_or_edit(update: Update, text: str, reply_markup=None):
             await message.edit_text(text, reply_markup=reply_markup)
     else:
         if message:
-            await message.reply_text(text, reply_markup=reply_markup)
+            sent = await message.reply_text(text, reply_markup=reply_markup)
+            if hasattr(context, 'chat_data'):
+                context.chat_data.setdefault('bot_messages', set()).add(sent.message_id)
 
 


### PR DESCRIPTION
## Summary
- add helper keyboard builder for cancel/back buttons
- extend task list keyboards with back button
- preserve bot message IDs and clear chat on `/start`
- add cancel buttons for various input prompts
- register global cancel callback

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6853fc6d37988327ba6daa2c364ef866