### PR TITLE
Reset filters on /start

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -30,6 +30,8 @@ async def start(update: Update, context: CallbackContext):
     if update.callback_query:
         await update.callback_query.answer()
     chat_id = update.effective_chat.id
+    # Clear any saved filters to avoid showing a filtered task list
+    context.user_data['filters'] = {}
     for mid in context.chat_data.get('bot_messages', set()):
         try:
             await context.bot.delete_message(chat_id=chat_id, message_id=mid)


### PR DESCRIPTION
## Summary
- reset `context.user_data['filters']` when handling `/start`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_686511932ca48327908636a49666fef1