### PR TITLE
Improve debugging of DB data

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -103,6 +103,9 @@ def load_tasks():
         t["tags"] = [r[0] for r in rows]
         t["done"] = bool(t["done"])
     conn.close()
+    print(f"DEBUG: load_tasks -> {len(tasks)} tasks")
+    if not tasks:
+        print("WARNING: load_tasks returned empty list")
     return tasks
 
 
@@ -135,7 +138,11 @@ def load_categories():
     conn = sqlite3.connect(DB_FILE)
     rows = conn.execute("SELECT name FROM categories ORDER BY name").fetchall()
     conn.close()
-    return [r[0] for r in rows]
+    categories = [r[0] for r in rows]
+    print(f"DEBUG: load_categories -> {len(categories)} categories")
+    if not categories:
+        print("WARNING: load_categories returned empty list")
+    return categories
 
 
 def save_categories(categories):
@@ -153,7 +160,11 @@ def load_tags():
     conn = sqlite3.connect(DB_FILE)
     rows = conn.execute("SELECT name FROM tags ORDER BY name").fetchall()
     conn.close()
-    return [r[0] for r in rows]
+    tags = [r[0] for r in rows]
+    print(f"DEBUG: load_tags -> {len(tags)} tags")
+    if not tags:
+        print("WARNING: load_tags returned empty list")
+    return tags
 
 
 def load_active_tags():
@@ -168,7 +179,11 @@ def load_active_tags():
         """
     ).fetchall()
     conn.close()
-    return [r[0] for r in rows]
+    tags = [r[0] for r in rows]
+    print(f"DEBUG: load_active_tags -> {len(tags)} tags")
+    if not tags:
+        print("WARNING: load_active_tags returned empty list")
+    return tags
 
 
 def load_settings():
@@ -177,7 +192,11 @@ def load_settings():
     conn.row_factory = sqlite3.Row
     rows = conn.execute("SELECT key, value FROM settings").fetchall()
     conn.close()
-    return {row["key"]: row["value"] for row in rows}
+    settings = {row["key"]: row["value"] for row in rows}
+    print(f"DEBUG: load_settings -> {len(settings)} entries")
+    if not settings:
+        print("WARNING: load_settings returned empty dict")
+    return settings
 
 
 def save_setting(key, value):

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -55,6 +55,7 @@ async def start(update: Update, context: CallbackContext):
 async def list_tasks(update: Update, context: CallbackContext):
     print('DEBUG: list_tasks')
     tasks = load_tasks()
+    print(f'DEBUG: list_tasks loaded {len(tasks)} tasks')
     filters_data = context.user_data.get('filters', {})
     category = filters_data.get('category')
     priority = filters_data.get('priority')
@@ -65,6 +66,9 @@ async def list_tasks(update: Update, context: CallbackContext):
         tasks = [t for t in tasks if t.get('priority') == priority]
     if tag:
         tasks = [t for t in tasks if tag in t.get('tags', [])]
+    print(f'DEBUG: list_tasks after filtering -> {len(tasks)} tasks')
+    if not tasks:
+        print('WARNING: list_tasks resulting list is empty')
     markup = build_keyboard(tasks, include_add_button=True, include_back_button=True)
     text = 'Ваши задачи:' if tasks else 'Задач нет.'
     await reply_or_edit(update, context, text, reply_markup=markup)
@@ -222,6 +226,8 @@ async def save_comment(update: Update, context: CallbackContext):
             task['done'] = True
             task['comment'] = comment
             break
+    done_count = sum(1 for t in tasks if t.get('done'))
+    print(f'DEBUG: save_comment marked task {task_id} done. Done count {done_count}')
     save_tasks(tasks)
     try:
         sent = await update.message.reply_text('Задача сохранена.')
@@ -240,6 +246,7 @@ async def delete_task(update: Update, context: CallbackContext):
     task_id = int(query.data.split('_')[1])
     tasks = load_tasks()
     tasks = [t for t in tasks if t['id'] != task_id]
+    print(f'DEBUG: delete_task remaining {len(tasks)} tasks')
     save_tasks(tasks)
     if query.message:
         try:
@@ -259,6 +266,8 @@ async def restore_task(update: Update, context: CallbackContext):
         if task['id'] == task_id:
             task['done'] = False
             break
+    done_count = sum(1 for t in tasks if t.get('done'))
+    print(f'DEBUG: restore_task restored {task_id}. Done count {done_count}')
     save_tasks(tasks)
     if query.message:
         try:
@@ -385,6 +394,7 @@ async def add_task_tags(update: Update, context: CallbackContext):
         'done': False,
         'comment': '',
     })
+    print(f'DEBUG: add_task_tags added task id {new_id}. Total {len(tasks)} tasks')
     save_tasks(tasks)
     try:
         sent = await update.message.reply_text('Задача добавлена.')
@@ -404,6 +414,7 @@ async def categories_menu(update: Update, context: CallbackContext):
     else:
         message = update.message
     categories = load_categories()
+    print(f'DEBUG: categories_menu -> {len(categories)} categories')
     keyboard = [
         [InlineKeyboardButton(cat, callback_data=f'editcat_{i}'), InlineKeyboardButton('🗑️', callback_data=f'delcat_{i}')]
         for i, cat in enumerate(categories)

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -9,6 +9,7 @@ def build_cancel_keyboard(text: str = 'Отмена') -> InlineKeyboardMarkup:
 def build_keyboard(tasks, include_add_button: bool = False, include_back_button: bool = False) -> InlineKeyboardMarkup | None:
     print('DEBUG: build_keyboard')
     keyboard = []
+    print(f'DEBUG: build_keyboard received {len(tasks)} tasks')
     for task in tasks:
         if not task.get('done'):
             keyboard.append([
@@ -28,13 +29,16 @@ def build_keyboard(tasks, include_add_button: bool = False, include_back_button:
     if include_back_button:
         keyboard.append([InlineKeyboardButton('Назад', callback_data='cancel')])
     if keyboard:
+        print(f'DEBUG: build_keyboard -> {len(keyboard)} rows')
         return InlineKeyboardMarkup(keyboard)
+    print('WARNING: build_keyboard produced empty keyboard')
     return InlineKeyboardMarkup([[InlineKeyboardButton('Добавить задачу', callback_data='add_task')]]) if include_add_button else None
 
 
 def build_completed_keyboard(tasks, include_back_button: bool = False) -> InlineKeyboardMarkup | None:
     print('DEBUG: build_completed_keyboard')
     keyboard = []
+    print(f'DEBUG: build_completed_keyboard received {len(tasks)} tasks')
     for task in tasks:
         if task.get('done'):
             keyboard.append([
@@ -47,6 +51,7 @@ def build_completed_keyboard(tasks, include_back_button: bool = False) -> Inline
     if include_back_button:
         keyboard.append([InlineKeyboardButton('Назад', callback_data='cancel')])
     if keyboard:
+        print(f'DEBUG: build_completed_keyboard -> {len(keyboard)} rows')
         return InlineKeyboardMarkup(keyboard)
     return None
 


### PR DESCRIPTION
## Summary
- add debug checks in database access functions
- log counts in handlers when tasks/categories change
- print debug info in keyboard builders

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68653f6d72488327a5c0007a8a24e110