### PR TITLE
Явная передача user_id для ежедневных задач

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ApplicationBuilder, CallbackContext, CallbackQueryHandler, CommandHandler, ConversationHandler, MessageHandler, filters
 
-from .config import BOT_TOKEN, OWNER_CHAT_ID
+from .config import BOT_TOKEN
 from .constants import *
 from .db import (
     init_db,
@@ -29,13 +29,14 @@ from .keyboards import (
 from .utils import schedule_reminder_job, reply_or_edit, send_and_store
 
 
-async def send_daily_tasks(context: CallbackContext, user_id: int | None = None):
+async def send_daily_tasks(context: CallbackContext, user_id: int):
     print("DEBUG: send_daily_tasks")
     if user_id is None:
-        if getattr(context, "job", None) and context.job.data:
-            user_id = context.job.data.get("user_id", OWNER_CHAT_ID)
-        else:
-            user_id = OWNER_CHAT_ID
+        logger.error("user_id is required for send_daily_tasks")
+        return
+    if user_id not in get_all_users():
+        logger.error("send_daily_tasks called for unregistered user %s", user_id)
+        return
     tasks = load_tasks(user_id)
     markup = build_keyboard(tasks)
     text = 'Задачи на сегодня:' if markup else 'На сегодня задач нет.'

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,4 +1,5 @@
 from datetime import time
+from functools import partial
 from telegram import Update
 import logging
 from telegram.ext import Application
@@ -22,11 +23,10 @@ def schedule_reminder_job(application: Application):
         notify_weekends = settings.get("notify_weekends", "0") == "1"
         days = (0, 1, 2, 3, 4, 5, 6) if notify_weekends else (0, 1, 2, 3, 4)
         application.job_queue.run_daily(
-            send_daily_tasks,
+            partial(send_daily_tasks, user_id=user_id),
             time(hour=hour, minute=minute),
             days=days,
             name=f"daily_{user_id}",
-            data={"user_id": user_id},
         )
 
 


### PR DESCRIPTION
## Summary
- Требование явного `user_id` в `send_daily_tasks` и проверка регистрации пользователя
- Передача `user_id` при планировании напоминаний через `schedule_reminder_job`

## Testing
- `python3 -m py_compile bot/handlers.py bot/utils.py`
- `python3 -m pytest` *(ошибка: No module named pytest)*
- `python3 -m pip install pytest` *(ошибка: No module named pip)*
- `apt-get update` *(ошибка: репозитории не подписаны)*

------
https://chatgpt.com/codex/tasks/task_b_68be57a7636c832793ec9fb223e43dc7