### PR TITLE
Add task list pagination and quick add command

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -18,3 +18,6 @@
     SETTINGS_TIME,
     FILTER_MENU,
 ) = range(17)
+
+
+TASKS_PER_PAGE = 10

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -6,7 +6,13 @@ def build_cancel_keyboard(text: str = 'Отмена') -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton(text, callback_data='cancel')]])
 
 
-def build_keyboard(tasks, include_add_button: bool = False, include_back_button: bool = False) -> InlineKeyboardMarkup | None:
+def build_keyboard(
+    tasks,
+    include_add_button: bool = False,
+    include_back_button: bool = False,
+    page: int | None = None,
+    total_pages: int | None = None,
+) -> InlineKeyboardMarkup | None:
     print('DEBUG: build_keyboard')
     keyboard = []
     print(f'DEBUG: build_keyboard received {len(tasks)} tasks')
@@ -24,6 +30,14 @@ def build_keyboard(tasks, include_add_button: bool = False, include_back_button:
                 InlineKeyboardButton('✏️', callback_data=f"edit_{task['id']}"),
                 InlineKeyboardButton('🗑️', callback_data=f"delete_{task['id']}"),
             ])
+    if page is not None and total_pages is not None and total_pages > 1:
+        nav_row = []
+        if page > 0:
+            nav_row.append(InlineKeyboardButton('◀️', callback_data=f'tasks_page_{page - 1}'))
+        nav_row.append(InlineKeyboardButton(f'{page + 1}/{total_pages}', callback_data='tasks_page_info'))
+        if page < total_pages - 1:
+            nav_row.append(InlineKeyboardButton('▶️', callback_data=f'tasks_page_{page + 1}'))
+        keyboard.append(nav_row)
     if include_add_button:
         keyboard.append([InlineKeyboardButton('Добавить задачу', callback_data='add_task')])
     if include_back_button:


### PR DESCRIPTION
## Summary
- introduce a TASKS_PER_PAGE constant and paginate task listings in daily reminders and the main task view with navigation buttons
- extend the inline keyboard builder to render pagination controls and register handlers to process page changes safely resetting the stored page on start and filter changes
- add a short /new command as an alternative entry point to the task creation flow

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_b_68d0f65ed738832795fe1e1125795103