### PR TITLE
Clear existing user reminder jobs before scheduling

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -14,9 +14,9 @@ def schedule_reminder_job(application: Application):
     from .handlers import send_daily_tasks  # local import to avoid circular
     if not application.job_queue:
         return
-    for job in application.job_queue.get_jobs_by_name("daily"):
-        job.schedule_removal()
     for user_id in get_all_users():
+        for job in application.job_queue.get_jobs_by_name(f"daily_{user_id}"):
+            job.schedule_removal()
         settings = load_settings(user_id)
         time_str = settings.get("reminder_time", "09:00")
         hour, minute = map(int, time_str.split(":"))


### PR DESCRIPTION
## Summary
- remove any existing per-user reminder jobs before scheduling new ones
- keep daily reminder jobs named per user to allow cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4dd1bea70832799b63865bcf7c608